### PR TITLE
Feat: 백준 14567 선수과목 풀이

### DIFF
--- a/woogun/Baekjoon/BOJ_14567.py
+++ b/woogun/Baekjoon/BOJ_14567.py
@@ -1,0 +1,43 @@
+# https://www.acmicpc.net/problem/14567
+# 백준 14567 선수과목
+# 위상 정렬 알고리즘을 이용한 풀이
+
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+
+def topological_sorting(que):
+    while que:
+        node, count = que.popleft()
+
+        for next_node in graph[node]:
+            degree[next_node] -= 1 # 해당 노드와 연결된 간선 제거
+
+            if degree[next_node] == 0: # 진입차수가 0이되면 que에 삽입
+                que.append((next_node, count + 1))
+                answer[next_node] = count + 1
+
+
+N, M = map(int, input().split()) # 과목의 수, 선수 과목의 수
+degree = [0] * (N+1) # 진입 차수를 담는 리스트
+graph = [[] for _ in range(N+1)] # 정점을 담는 리스트
+answer = [0] * (N+1) # 출력 정답을 담는 리스트
+
+for i in range(M):
+    subject1, subject2 = map(int, input().split())
+    graph[subject1].append(subject2) # 단방향 그래프 세팅
+    degree[subject2] += 1 # 진입차수 세팅
+
+que = deque()
+
+# 진입 차수가 0인 정점이면 que에 넣는다.
+for i in range(1, len(degree)):
+    if degree[i] == 0:
+        answer[i] = 1
+        que.append((i, 1)) # 차수가 0인 정점, 몇번째 과목인지
+
+topological_sorting(que) # 위상 정렬 시작
+
+answer = answer[1:]
+print(*answer)


### PR DESCRIPTION
## 링크
https://www.acmicpc.net/problem/14567

## Solve
위상정렬을 이용한 풀이
![image](https://github.com/ALGORITM-MASTER/ALGORITM/assets/91789276/23fbef2f-8db6-45f1-896c-b4d616b9ecdb)


### 분석 <!-- 문제 접근 방식 -->
위상정렬은 어떤 그래프를 방문할 때 선수 방문 하는 노드가 있는지 판별하는 알고리즘 입니다.
위상정렬을 이용한 알고리즘 풀이에는 2가지 조건이 있습니다.

1. 단방향 그래프여야만 한다.
2. 그래프의 사이클을 가져서는 안된다.

풀이 방법으로는 다음과 같습니다.

자료구조: 주어진 노드를 그래프 구조로 만들고 진입차수를 설정한다.

풀이:
1. 진입차수가 0인 노드를 que에 담는다.
2. que에서 노드를 꺼내어 해당 노드와 연결되어 있는 간선을 모두 제거한다. (진입 차수 -=1)
3. 진입 차수가 0이 되면 que에 다시 삽입한다.
4. 이 때 que에서 꺼낸 순서가 위상 정렬의 결과가 된다.
5. 이를 que가 빌 때 까지 반복

## 특이사항 및 질문사항 <!-- 특이사항 및 질문사항 -->
위상 정렬의 시간복잡도는 O(V + E) 이다.
