### PR TITLE
feat: two circle pair

### DIFF
--- a/박세연/ct/src/main/java/org/example/level2/TwoCirclePair.java
+++ b/박세연/ct/src/main/java/org/example/level2/TwoCirclePair.java
@@ -1,0 +1,26 @@
+package org.example.level2;
+
+public class TwoCirclePair {
+	public static long solution(int r1, int r2) {
+		long answer = 0;
+
+		double rr1 = Math.pow(r1,2);
+		double rr2 = Math.pow(r2,2);
+
+		for (int i = 0; i <= r2; i++) {
+			int bigY = (int)findY(rr2, i);
+			double smallY = 0;
+			if (r1 > i) {
+				smallY = findY(rr1, i);
+			}
+
+			answer += (int)(bigY - smallY) + 1;
+		}
+
+		return answer * 4 - (r2-r1+1)*4;
+	}
+
+	private static double findY(double rr, int x) {
+		return Math.sqrt(rr - Math.pow(x,2));
+	}
+}

--- a/박세연/ct/src/test/java/org/example/level2/Level2Test.java
+++ b/박세연/ct/src/test/java/org/example/level2/Level2Test.java
@@ -49,4 +49,14 @@ class Level2Test {
 			arguments(2, 4, new int[] {3,3,3,3}, 4)
 		);
 	}
+
+	@DisplayName("두 원 사이의 정수 쌍")
+	@ParameterizedTest
+	@CsvSource({
+		"2, 3, 20"
+	})
+	void two_circle_pair(int r1, int r2, int result) {
+	    // Given, When, Then
+		assertThat(TwoCirclePair.solution(r1,r2)).isEqualTo(result);
+	}
 }


### PR DESCRIPTION
## 링크

[두 원 사이의 정수 쌍](https://school.programmers.co.kr/learn/courses/30/lessons/181187#)

## Solve
[풀이 코드]
![image](https://github.com/ALGORITM-MASTER/ALGORITM/assets/54196094/3471a318-fd95-4193-b933-9f16f02c8553)


[만약 기존 생각대로 코드를 작성했다면 나왔을 시간] 
![image](https://github.com/ALGORITM-MASTER/ALGORITM/assets/54196094/dcce7113-8449-4e0f-bd16-7369b433cef1)

작은 데이터에서도 큰 시간 차이가 발생하는 것을 볼 수 있다. 자세한 건 `분석`에서 풀이하겠다.


### 분석 <!-- 문제 접근 방식 -->
`두 원 사이에 존재하는 정수 좌표의 갯수를 구하는 문제`이다.

해결하는데 1시간이 넘게 걸렸다.. 이후는 아래에서 설명하겠다.

간단한 문제이고, 여러 방식이 있을 거고,

처음 접근은 `원의 방정식`에서 값을 대입하여 그 값보다 작은 경우 안쪽, 크면 밖인 것을 활용하며 문제를 풀 수 있다 하지만 이렇게 하면 `이중 for`문을 통해 큰 원 내부의 점의 좌표 갯수만큼 for문을 돌려야 한다.

이렇게 되면  많은 시간을 잡아 먹기 때문에 좀 더 최적화를 할 수 있는 방법이 바로 떠올라 다른 방식을 적용했다.

`한 x좌표에 대한 y값의 비교를 통해 두 값 사이의 점의 갯수`를 구하는 방식으로 해결하였다.
두 지점 사이의 갯수를 구할때 가장 생각해야 했던 것은 x나 y좌표의 경우 `실수`로 나올 수 있기 때문에 이 `실수의 경우 어떻게 처리할 것인가?` 였다.

먼저 큰 원의 경우, 어떤 실수가 나오더라도 그 정수부만 포함하여 판단하면 된다. 따라서 바로 정수로 변경을 하면 되므로 간단하다.
반대로, 작은 원의 경우, 어떻게 처리할 것인지에 따라 추가적으로 더하거나 빼는 부분에 대한 로직이 발생하기 때문에 생각을 해야한다. 

작은 원의 y값
- 정수: 해당 정수를 포함하여 계산 
- 실수: 해당 정수보다 하나 큰 수까지만 세어야 한다.

이를 기반으로 코드를 작성하면 되는데, 하나 더 생각할 것은 작은 원의 반지름보다 계산하고자 하는 y값에 대한 x값이 작을 때이다. 이때는 결과 값을 항상 0으로 계산하면 된다.

```
int bigY = (int)findY(rr2, i);
double smallY = 0;
if (r1 > i) {
	smallY = findY(rr1, i);
}
answer += (int)(bigY - smallY) + 1;
```
이렇게 각 x값에 대해서 계산한 후 마지막 공통된 부분에 대해서 삭제해 주면 된다.

## 특이사항 및 질문사항 <!-- 특이사항 및 질문사항 -->
1시간 걸린 이유...

x의 제곱을 구하기 위해 x*x를 사용하고 이를 int로 받았다. 대략 4만 2천번대 이상부터 정수의 정수의 범위를 벗어나기 때문에 에러가 발생했는데 로직만 생각하다가 못 잡고 많은 시간이 걸렸다.

이전에는 발생하지 않았을 에러인데, 최근에 감이 떨어지기도 했고 java로 넘어오고 큰 숫자에 대한 값을 생각하는 문제나 프로젝트에서 사용하지 않았다 보니 이런 문제가 발생한 거 같다.