### PR TITLE
feat: 광물 캐기, 프로그래머스 2단계 solve

### DIFF
--- a/박세연/ct/src/main/java/org/example/level2/Mineral.java
+++ b/박세연/ct/src/main/java/org/example/level2/Mineral.java
@@ -1,0 +1,69 @@
+package org.example.level2;
+
+import java.util.*;
+
+public class Mineral {
+	private static final int MINERAL_COUNT = 5;
+
+	public static int solution(int[] picks, String[] minerals) {
+		int answer = 0;
+
+		Map<String, int[]> mineralValue = new HashMap<>();
+		mineralValue.put("diamond", new int[] {1, 5, 25});
+		mineralValue.put("iron", new int[] {1, 1, 5});
+		mineralValue.put("stone", new int[] {1, 1, 1});
+
+		List<int[]> rounds = new ArrayList<>();
+		for (int i = 0; i < minerals.length; i++) {
+			if (i % MINERAL_COUNT == 0) {
+				rounds.add(new int[3]);
+			}
+
+			rounds.get(i / MINERAL_COUNT)[0] +=  mineralValue.get(minerals[i])[0];
+			rounds.get(i / MINERAL_COUNT)[1] +=  mineralValue.get(minerals[i])[1];
+			rounds.get(i / MINERAL_COUNT)[2] +=  mineralValue.get(minerals[i])[2];
+		}
+
+		int totalPicks = picks[0] + picks[1] + picks[2];
+		int matchSize = rounds.size();
+		if (totalPicks < rounds.size()) {
+			matchSize = totalPicks;
+		}
+
+		while (rounds.size() > matchSize) {
+			rounds.remove(rounds.size() - 1);
+		}
+
+		rounds.sort((round1, round2) -> {
+			if (round1[2] < round2[2]) {
+				return 1;
+			} else if (round1[2] > round2[2]) {
+				return -1;
+			}
+
+			if (round1[1] < round2[1]) {
+				return 1;
+			} else if (round1[1] > round2[1]) {
+				return -1;
+			}
+
+			return -1;
+		});
+
+		int pickIndex = 0;
+		int roundIndex = 0;
+
+		while (roundIndex < matchSize) {
+			if (picks[pickIndex] == 0) {
+				pickIndex++;
+				continue;
+			}
+
+			answer += rounds.get(roundIndex)[pickIndex];
+			roundIndex++;
+			picks[pickIndex]--;
+		}
+
+		return answer;
+	}
+}

--- a/박세연/ct/src/test/java/org/example/level2/Level2Test.java
+++ b/박세연/ct/src/test/java/org/example/level2/Level2Test.java
@@ -49,4 +49,23 @@ class Level2Test {
 			arguments(2, 4, new int[] {3,3,3,3}, 4)
 		);
 	}
+
+	@DisplayName("광물 캐기")
+	@ParameterizedTest
+	@MethodSource("mineral_param")
+	void mineral(int[] picks, String[] minerals, int result) {
+		assertThat(Mineral.solution(picks, minerals)).isEqualTo(result);
+	}
+
+	Stream<Arguments> mineral_param() {
+		return Stream.of(
+			arguments(new int[] {1, 3, 2},
+				new String[] {"diamond", "diamond", "diamond", "iron", "iron", "diamond", "iron", "stone"},
+				12),
+			arguments(new int[] {0, 1, 1}, new String[] {"diamond", "diamond", "diamond", "diamond", "diamond",
+				"iron", "iron", "iron", "iron", "iron", "diamond"},
+				50)
+		);
+	}
+
 }


### PR DESCRIPTION
## 링크

[광물 캐기](https://school.programmers.co.kr/learn/courses/30/lessons/172927)

## Solve
구현

### 분석 <!-- 문제 접근 방식 -->

dp로 풀까, 구현으로 풀까 고민을 했습니다.

dp와 bfs를 같이 사용한 경우 최적의 값을 계속 가지고 있게 되지만 최종적으로 mineral의 길이가 50개이며, 곡갱이가 3개이다 보니 배열의 크기가 커져서, picks의 총 갯수^50의 사이즈를 가지게 됩니다.
따라서 그냥 구현이 더 좋을 거 같다 판단하여

```
Map<String, int[]> mineralValue = new HashMap<>();
mineralValue.put("diamond", new int[] {1, 5, 25});
mineralValue.put("iron", new int[] {1, 1, 5});
mineralValue.put("stone", new int[] {1, 1, 1});
```
- 각 미네랄에 대한 피로도를 담는 변수입니다.

```
List<int[]> rounds = new ArrayList<>();
for (int i = 0; i < minerals.length; i++) {
        if (i % MINERAL_COUNT == 0) {
                rounds.add(new int[3]);
        }
            
        rounds.get(i / MINERAL_COUNT)[0] +=  mineralValue.get(minerals[i])[0];
        rounds.get(i / MINERAL_COUNT)[1] +=  mineralValue.get(minerals[i])[1];
        rounds.get(i / MINERAL_COUNT)[2] +=  mineralValue.get(minerals[i])[2];
}
```
- 한 번 캐면 5개의 광물을 무조건 캐야하기 때문에 5개의 마다 사용되는 피로도를 구하는 변수입니다.
- 이렇게 하면 최대 50개여도 10개로 탐색하는 갯수가 줄어들게 됩니다.



## 특이사항 및 질문사항 <!-- 특이사항 및 질문사항 -->
