### PR TITLE
feat: 우박수열 정적분, 프로그래머스 2단계

### DIFF
--- a/박세연/ct/src/main/java/org/example/level2/UParkIntegral.java
+++ b/박세연/ct/src/main/java/org/example/level2/UParkIntegral.java
@@ -1,0 +1,51 @@
+package org.example.level2;
+
+import java.util.*;
+
+public class UParkIntegral {
+	public static double[] solution(int k, int[][] ranges) {
+		List<Integer> y = new ArrayList<>();
+		y.add(k);
+
+		while (k != 1) {
+			k = nextStep(k);
+			y.add(k);
+		}
+
+		List<Double> integralDp = calcIntegralDp(y);
+		List<Double> result = new ArrayList<>();
+
+		for(int[] range : ranges) {
+			int last = (y.size() - 1) + range[1];
+			int start = range[0];
+			if (last < 0 || start > y.size() - 1 || last < start) {
+				result.add(-1.0);
+				continue;
+			}
+
+			result.add(integralDp.get(last) - integralDp.get(start));
+		}
+
+		return result.stream()
+			.mapToDouble(Double::doubleValue)
+			.toArray();
+	}
+
+	private static int nextStep(int data) {
+		if (data % 2 == 0) {
+			return data / 2;
+		}
+
+		return data * 3 + 1;
+	}
+
+	private static List<Double> calcIntegralDp(List<Integer> y) {
+		List<Double> dp = new ArrayList<>();
+		dp.add(0.0);
+
+		for (int i = 1; i < y.size(); i++) {
+			dp.add((double)(y.get(i-1) + y.get(i)) / 2 + dp.get(i-1));
+		}
+		return dp;
+	}
+}

--- a/박세연/ct/src/test/java/org/example/level2/Level2Test.java
+++ b/박세연/ct/src/test/java/org/example/level2/Level2Test.java
@@ -1,14 +1,12 @@
 package org.example.level2;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.*;
 
-import java.util.Collections;
-import java.util.PriorityQueue;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -16,7 +14,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class Level2Test {
@@ -71,11 +68,26 @@ class Level2Test {
 
 	@DisplayName("두 원 사이의 정수 쌍")
 	@ParameterizedTest
-	@CsvSource({
-		"2, 3, 20"
-	})
+	@CsvSource("2, 3, 20")
 	void two_circle_pair(int r1, int r2, int result) {
 	    // Given, When, Then
 		assertThat(TwoCirclePair.solution(r1,r2)).isEqualTo(result);
+	}
+
+	@DisplayName("우박수열 정적분")
+	@ParameterizedTest
+	@MethodSource("uParkIntegral_param")
+	void uParkIntegral_test(int k, int[][] ranges, double[] result) {
+	    // Given, When, Then
+		assertThat(UParkIntegral.solution(k, ranges)).isEqualTo(result);
+	}
+
+	Stream<Arguments> uParkIntegral_param() {
+		return Stream.of(
+			arguments(5,new int[][] {{0,0}, {0,-1}, {2,-3}, {3,-3}},
+				new double[] {33.0,31.5,0.0,-1.0}),
+			arguments(3, new int[][] {{0,0}, {1,-2}, {3,-3}},
+				new double[] {47.0,36.0,12.0})
+		);
 	}
 }


### PR DESCRIPTION
## 링크

[우박수열 정적분](https://school.programmers.co.kr/learn/courses/30/lessons/134239)

## Solve
20분대 였던 걸로 기억

### 분석 <!-- 문제 접근 방식 -->
문제에서는 구간에 따른 정적분 값을 구해야 하기 때문에 매번 구간에 대한 정적분 값을 구하는 것은 비효율적이라 판단.
바로 생각났던 풀이는 dp를 사용하면 되겠다 판단이 되었다.

따라서
```
 List<Integer> y = new ArrayList<>();
y.add(k);
    
while (k != 1) {
        k = nextStep(k);
        y.add(k);
}

private int nextStep(int data) {
        if (data % 2 == 0) {
            return data / 2;
        }
        
        return data * 3 + 1;
}
```
위와 같이 콜라츠 추측에 대한 y값을 구하고

해당 y값으로 구간에 따른 정적분 값을 dp로 계산해 놓았다.
```
private List<Double> calcIntegralDp(List<Integer> y) {
        List<Double> dp = new ArrayList<>();
        dp.add(0.0);
        
        for (int i = 1; i < y.size(); i++) {
            dp.add((double)(y.get(i-1) + y.get(i)) / 2 + dp.get(i-1));
        }
        return dp;
}
```

마지막으로 dp값을 기반으로 구간의 정적분 값을 구하면 된다.
```
for(int[] range : ranges) {
            int last = (y.size() - 1) + range[1];
            int start = range[0];
            if (last < 0 || start > y.size() - 1 || last < start) {
                result.add(-1.0);
                continue;
            }
            
            result.add(integralDp.get(last) - integralDp.get(start));
}
```
- 다만, 구간이 잘못된 경우 -1을 넣으면 되기 때문에 조건으로 사전 처리

이후 List<Double>로 되어있는 값을 double[]로 변경해줘야하기 때문에
```
return result.stream()
	.mapToDouble(Double::doubleValue)
	.toArray();
```
- 변환하여 반환한다.

## 특이사항 및 질문사항 <!-- 특이사항 및 질문사항 -->