### PR TITLE
Feat: 백준 5639 이진 검색 트리 풀이

### DIFF
--- a/woogun/Baekjoon/BOJ_3192.py
+++ b/woogun/Baekjoon/BOJ_3192.py
@@ -27,6 +27,7 @@ def find_total_number():
             if square[j][i] == 0:
                 break
             temp_num += square[j][i]
+            count += 1
 
         if count == 3:
             return temp_num
@@ -54,6 +55,8 @@ def find_total_number():
 
     if count == 3:
         return temp_num
+
+    return 40001
 
 
 # 지워진 숫자 채워넣기

--- a/woogun/Baekjoon/BOJ_5639.py
+++ b/woogun/Baekjoon/BOJ_5639.py
@@ -1,0 +1,34 @@
+# https://www.acmicpc.net/problem/5639
+# 백준 5639 이진 검색 트리
+
+import sys
+sys.setrecursionlimit(10 ** 9)
+input = sys.stdin.readline
+
+input_list = []
+
+while True:
+    try:
+        input_list.append(int(input()))
+    except:
+        break
+
+
+def post_order(start, end):
+    if start > end:
+        return
+
+    root = input_list[start]
+    mid = end + 1 # 오른쪽 노드가 없는 경우 파악
+
+    for i in range(start + 1, end + 1):
+        if root < input_list[i]:
+            mid = i
+            break
+
+    post_order(start + 1, mid - 1) # 왼쪽 노드 탐색
+    post_order(mid, end)           # 오른쪽 노드 탐색
+    print(input_list[start])       # 루트 노드 출력
+
+
+post_order(0, len(input_list) - 1)


### PR DESCRIPTION
## 링크
https://www.acmicpc.net/problem/5639

## Solve
![image](https://github.com/ALGORITM-MASTER/ALGORITM/assets/91789276/acbeb4e3-5ab6-4b82-a73d-ee98aec8cf0b)

### 분석 <!-- 문제 접근 방식 -->
첫번째로 입력 받는 것에 대한 제한이 없어서 try ~ except로 입력을 끝까지 받을때까지 입력을 받도록 하였다.

처음에는 전위 순회 결과를 보고 새로운 트리를 만들어 후위 순회를 하도록 구현하였는데 시간초과가 났다.

구글링 좀 해본 결과 기존 입력을 가지고 루트 노드와 자식 노드의 크기를 비교하여 한 번에 후위 순회를 하도록 구현하였다.

## 특이사항 및 질문사항 <!-- 특이사항 및 질문사항 -->
후위 순회는 왼쪽 노드 -> 오른쪽 노드 -> 루트 노드 순으로 순회합니다.
