### PR TITLE
feat : 쉬운 계단 수

### DIFF
--- a/김효건/백준/dp/가장 긴 증가하는 부분 수열.py
+++ b/김효건/백준/dp/가장 긴 증가하는 부분 수열.py
@@ -1,0 +1,13 @@
+import sys
+
+n = int(input())
+dp = [1] * n
+
+arr = list(map(int, sys.stdin.readline().split()))
+
+for i in range(1,n):
+    for j in range(i):
+        if arr[i] > arr[j]:
+            dp[i] = max(dp[j]+1, dp[i])
+
+print(max(dp))

--- a/김효건/백준/dp/쉬운 계단 수.py
+++ b/김효건/백준/dp/쉬운 계단 수.py
@@ -1,0 +1,42 @@
+import sys
+
+n = int(sys.stdin.readline())
+dp = [[0] * 10 for i in range(n+1)]
+
+for i in range(1,10):
+    dp[0][i] = 1
+
+if n == 1:
+    print(9)
+
+for i in range(1,n+1):
+    for j in range(10):
+        if j == 0:
+            dp[i][j] = dp[i-1][j+1]
+
+        elif j == 9:
+            dp[i][j] = dp[i-1][j-1]
+
+        else:
+            dp[i][j] = dp[i-1][j-1] + dp[i-1][j+1]
+
+print(sum(dp[n-1])%1_000_000_000)
+
+
+
+# N = int(input())
+
+# dp = [[0]*10 for _ in range(N+1)]
+# for i in range(1, 10):
+#     dp[1][i] = 1
+
+# for i in range(2, N+1):
+#     for j in range(10):
+#         if j == 0:
+#             dp[i][j] = dp[i-1][1]
+#         elif j == 9:
+#             dp[i][j] = dp[i-1][8]
+#         else:
+#             dp[i][j] = dp[i-1][j-1] + dp[i-1][j+1] 
+
+# print(sum(dp[N]) % 1000000000)


### PR DESCRIPTION
## 링크

https://www.acmicpc.net/problem/10844

## Solve
<img width="727" alt="image" src="https://github.com/ALGORITM-MASTER/ALGORITM/assets/126091985/d56abd89-7c37-4262-88d5-e936a8367a96">

내 코드
```python3
import sys

n = int(sys.stdin.readline())
dp = [[0] * 10 for i in range(n+1)]

for i in range(1,10):
    dp[0][i] = 1

if n == 1:
    print(9)

for i in range(1,n+1):
    for j in range(10):
        if j == 0:
            dp[i][j] = dp[i-1][j+1]

        elif j == 9:
            dp[i][j] = dp[i-1][j-1]

        else:
            dp[i][j] = dp[i-1][j-1] + dp[i-1][j+1]

print(sum(dp[n-1])%1_000_000_000)
```
정답 코드
```python3
N = int(input())

dp = [[0]*10 for _ in range(N+1)]
for i in range(1, 10):
    dp[1][i] = 1

for i in range(2, N+1):
    for j in range(10):
        if j == 0:
            dp[i][j] = dp[i-1][1]
        elif j == 9:
            dp[i][j] = dp[i-1][8]
        else:
            dp[i][j] = dp[i-1][j-1] + dp[i-1][j+1] 

print(sum(dp[N]) % 1000000000)
```
### 분석 <!-- 문제 접근 방식 -->
n에 따라서 계단 수를 만들 수 있는 경우의 수를 구하는 문제이다. n이 1일 때(한 자리 숫자)는 0을 제외 한 나머지 1~9의 각각의 경우의 수를 1로 두어 n이 2 이상일 때 dp를 활용하여 문제를 푼다. n이 2이상일 때 현재 dp는 그 전 dp의 경우의 수를 더해 나가며 구한다. 단, 현재 dp의 위치는 이 전 수의 뒷자리로 붙는다고 생각하면 된다.
n이 1일 때 dp[0][0] ~ dp[0][9]로 설정했다. (여기서 dp[0][0]만 0이고 나머지는 1)
ex) 코드를 보면 알겠지만 dp[?][0], dp[?][9]는 계단 수가 101, 198와 같이 0->9, 9->0으로는 진행할 수 없고 나머지 수는 123, 121와 같이 두 가지 경우의 수가 존재하기 때문에 위와 같은 방식으로 구했다.

## 특이사항 및 질문사항 <!-- 특이사항 및 질문사항 -->

1,2,3번째 제출은 마지막 답 제출 시 1,000,000,000의 나머지를 구했어야 했는데 그냥 제출해서 4번째 제출 때 수정을 하고 제출했지만 오답이 났다. 아무리 생각해도 맞는 개념같은데 틀렸다고 나오니 인터넷 검색을 해서 내 코드와 비교해보았다. 아무리 보아도 푸는 방법은 같지만 코드가 조금 다를 뿐.... n이 2~10까지 모두 같은 값이 나와서 이상하다 생각했는데 생각해보니 1을 입력하면 9가 2번 출력이 되었다 ^^; 